### PR TITLE
multicore-safe version of StoreVector

### DIFF
--- a/src/StoreVector.ml
+++ b/src/StoreVector.ml
@@ -24,6 +24,11 @@ type 'a store = {
   (* The array, whose length is at least [limit]. *)
   mutable content: 'a array
 }
+(* Note: the invariant [s.limit <= Array.length s.content] is preserved
+   under sequential usage, but it may be violated by racy concurrent
+   uses of the store. We do not provide any correctness guarantee in this
+   case, but we preserve memory safety -- this prevents us from using
+   [unsafe_get] and [unsafe_set] on the [content] array. *)
 
 (* The array is created with a size and length of zero. We have no other
    choice, since we do not have a value of type ['a] at hand. *)
@@ -52,7 +57,6 @@ let default_initial_length =
 (* [enlarge s v] increases the length of the array (if necessary) so as to
    ensure that [s.limit] becomes a valid index. The argument [v] is used as a
    default value to fill the uninitialized area. *)
-
 let enlarge (s : 'a store) (v : 'a) : unit =
   let content = s.content in
   let length = Array.length content in
@@ -68,12 +72,20 @@ let enlarge (s : 'a store) (v : 'a) : unit =
     Array.blit content 0 content' 0 length;
     s.content <- content'
   end
+(* Note: the [enlarge] function may violate the
+     [s.limit <= Array.length s.content]
+   invariant in preseence of racy concurrent callers.
 
-(* Note that we cannot use [Array.unsafe_set] and [Array.unsafe_get] without
-   any precautions, since the OCaml type-checker cannot guarantee that the
-   indices are in range. A confused user could pass references into some
-   other store. We choose to explicitly check that the index is within the
-   logical bounds of the array -- this is a more precise check. *)
+   Consider a scenario when domain A makes a single call to [enlarge],
+   and concurrently domain B makes many calls to [make] and
+   [enlarge]. At the end of this parallel section, the (non-atomic)
+   write to [s.content] from A wins the race, and the (non-atomic)
+   write to [s.limit] from B wins the race; we may end up with
+   [s.limit] larger than [s.content].
+
+   We could protect against this by maintaining an atomic version
+   count to detect racy updates to the backing store.
+*)
 
 exception InvalidRef
 
@@ -88,16 +100,16 @@ let make (s : 'a store) (v : 'a) : 'a rref =
   enlarge s v;
   let x = s.limit in
   s.limit <- x + 1;
-  Array.unsafe_set s.content x v;
+  Array.set s.content x v;
   x
 
 let get (s : 'a store) (x : 'a rref) : 'a =
   check s x;
-  Array.unsafe_get s.content x
+  Array.get s.content x
 
 let set (s : 'a store) (x : 'a rref) (v : 'a) : unit =
   check s x;
-  Array.unsafe_set s.content x v
+  Array.set s.content x v
 
 let eq  (s : 'a store) (x : 'a rref) (y : 'a rref) : bool =
   check s x;


### PR DESCRIPTION
See the diff for lengthy explanations of why `unsafe_{get,set}` cannot be assumed correct with OCaml 5.

The performance results are fairly noisy on my machine.

Before, three timings: 6.6s, 6.1s, 6.9s
After, three timings: 6.3s, 6.6s, 6.7s

My performance conclusion is that this is fine.
It is not like we have a choice anyway, memory-unsoundess shall not be tolerated.